### PR TITLE
[FIX] Resolves crash from non-supported characters in ServerOptOut.java

### DIFF
--- a/src/main/java/mike/autototem/mixin/ServerOptOut.java
+++ b/src/main/java/mike/autototem/mixin/ServerOptOut.java
@@ -19,7 +19,7 @@ public class ServerOptOut {
         networkHandler.sendPacket(
             new CustomPayloadC2SPacket(
                 new PacketByteBuf(Unpooled.buffer())
-                    .writeString("Client uses the Autototem mod.")
+                    .writeString("client_uses_the_autototem_mod.")
             )
         );
     }


### PR DESCRIPTION
Resolves https://github.com/Developer-Mike/Autototem-Fabric/issues/8. Unsupported characters in `sendInfoPackage` method's string payload.