### PR TITLE
Fix invalid payload packet

### DIFF
--- a/src/main/java/mike/autototem/mixin/ServerOptOut.java
+++ b/src/main/java/mike/autototem/mixin/ServerOptOut.java
@@ -1,9 +1,10 @@
 package mike.autototem.mixin;
 
 import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.network.packet.BrandCustomPayload;
+import net.minecraft.network.packet.UnknownCustomPayload;
 import net.minecraft.network.packet.c2s.common.CustomPayloadC2SPacket;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,11 +15,13 @@ public class ServerOptOut {
     @Inject(at = @At("TAIL"), method = "onGameJoin")
     private void sendInfoPackage(GameJoinS2CPacket packet, CallbackInfo ci) {
         ClientPlayNetworkHandler networkHandler = (ClientPlayNetworkHandler) ((Object) this);
-        
+
         networkHandler.sendPacket(
-            new CustomPayloadC2SPacket(
-                new BrandCustomPayload("autototem")
-            )
+                new CustomPayloadC2SPacket(
+                        // Use a custom channel for compatibility with https://github.com/jonesdevelopment/sonar
+                        // and other anti-cheat, anti-exploit, and anti-bot plugins.
+                        new UnknownCustomPayload(Identifier.of("autototem-fabric"))
+                )
         );
     }
 }

--- a/src/main/java/mike/autototem/mixin/ServerOptOut.java
+++ b/src/main/java/mike/autototem/mixin/ServerOptOut.java
@@ -16,12 +16,9 @@ public class ServerOptOut {
     private void sendInfoPackage(GameJoinS2CPacket packet, CallbackInfo ci) {
         ClientPlayNetworkHandler networkHandler = (ClientPlayNetworkHandler) ((Object) this);
 
-        networkHandler.sendPacket(
-                new CustomPayloadC2SPacket(
-                        // Use a custom channel for compatibility with https://github.com/jonesdevelopment/sonar
-                        // and other anti-cheat, anti-exploit, and anti-bot plugins.
-                        new UnknownCustomPayload(Identifier.of("autototem-fabric"))
-                )
-        );
+        networkHandler.sendPacket(new CustomPayloadC2SPacket(
+                // Use a custom channel for compatibility with Sonar
+                // https://github.com/Developer-Mike/Autototem-Fabric/pull/15
+                new UnknownCustomPayload(Identifier.of("autototem-fabric"))));
     }
 }

--- a/src/main/java/mike/autototem/mixin/ServerOptOut.java
+++ b/src/main/java/mike/autototem/mixin/ServerOptOut.java
@@ -16,9 +16,10 @@ public class ServerOptOut {
     private void sendInfoPackage(GameJoinS2CPacket packet, CallbackInfo ci) {
         ClientPlayNetworkHandler networkHandler = (ClientPlayNetworkHandler) ((Object) this);
 
-        networkHandler.sendPacket(new CustomPayloadC2SPacket(
-                // Use a custom channel for compatibility with Sonar
-                // https://github.com/Developer-Mike/Autototem-Fabric/pull/15
-                new UnknownCustomPayload(Identifier.of("autototem-fabric"))));
+        networkHandler.sendPacket(
+            new CustomPayloadC2SPacket(
+                new UnknownCustomPayload(Identifier.of("autototem-fabric"))
+            )
+        );
     }
 }


### PR DESCRIPTION
The server opt-out feature is currently sending a duplicate payload packet (non-vanilla behaviour) with the channel `minecraft:brand` which flags anti-cheat, anti-exploit, and anti-bot plugins.

As an anti-bot developer myself, I've received several reports of users who have this mod installed trying to join servers protected by my anti-bot plugin, [Sonar](<https://github.com/jonesdevelopment/sonar>).

This PR fixes this issue by using a custom payload channel instead of Minecraft's brand channel.

This way, servers are able to opt-out, and people no longer have problems logging in to some servers, especially the ones using my plugin.